### PR TITLE
Support sorting for MS SQLServer layer.

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -1564,7 +1564,7 @@ int msLayerApplyPlainFilterToLayer(FilterEncodingNode *psNode, mapObj *map, int 
 int msLayerSupportsSorting(layerObj *layer)
 {
   if (layer && (
-    (layer->connectiontype == MS_OGR) || (layer->connectiontype == MS_POSTGIS) || (layer->connectiontype == MS_ORACLESPATIAL) || ((layer->connectiontype == MS_PLUGIN) && (strstr(layer->plugin_library,"msplugin_oracle") != NULL))
+    (layer->connectiontype == MS_OGR) || (layer->connectiontype == MS_POSTGIS) || (layer->connectiontype == MS_ORACLESPATIAL) || ((layer->connectiontype == MS_PLUGIN) && (strstr(layer->plugin_library,"msplugin_oracle") != NULL || strstr(layer->plugin_library,"msplugin_mssql2008") != NULL))
                )
      )
     return MS_TRUE;


### PR DESCRIPTION
Without this change, it will cause an error when the sql statement contains 'Order By' clause for a SQL Server layer.